### PR TITLE
 Enabling vertical scrolling if the content inside is taller than the menu

### DIFF
--- a/apps/core/static/core/css/navbar.css
+++ b/apps/core/static/core/css/navbar.css
@@ -221,6 +221,7 @@
         flex-direction: column;
         margin: 0;
         transform: none !important;
+        overflow-y: auto;
     }
     
     .navbar .menu.active {


### PR DESCRIPTION
core/css/navbar.css: Add 'overflow-y: auto' into .navbar .menu to enable vertical scrolling if the content inside is taller than the menu